### PR TITLE
Fix bug with VERBOSE output in bs cmd

### DIFF
--- a/bps
+++ b/bps
@@ -52,7 +52,7 @@ oc get pods --all-namespaces --field-selector=status.phase=Running ${FIELDS[@]} 
   | map({
       node:  .[0].node,
       total: map(.gpus) | add,
-      pods: map(.pod) | unique
+      pods: map(select(.gpus > 0) | .pod) | unique
     })
   # And finally print “node: N GPUs”
   | map(


### PR DESCRIPTION
When VERBOSE=1 the script includes all pods (even those with 0 GPU requests) on a given node in the initial filter, and then includes ALL those pods in the final output. We only want the output to contain pods that actually request/utilize a GPU on that node.